### PR TITLE
Fix AttributeError with babelfont 3.x: styleName → name

### DIFF
--- a/Lib/fontprimer/__init__.py
+++ b/Lib/fontprimer/__init__.py
@@ -295,7 +295,7 @@ class FontPrimer(GFBuilder):
         filename = (
             new_family_name.replace(" ", "")
             + "-"
-            + instance.styleName.get_default().replace(" ", "")
+            + instance.name.get_default().replace(" ", "")
         )
         if "staticTemplate" in self.config:
             outdir = self.static_template(variant, guidelines, output)


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent (Claude) working under the guidance of @felipesanches, but submitted **without human review**. @felipesanches himself would still need to participate in the PR thread if he wants to contribute to the review.

## Summary

- Fix `AttributeError: 'Instance' object has no attribute 'styleName'` when using babelfont 3.x
- One-line change: `instance.styleName.get_default()` → `instance.name.get_default()`

Fixes #4

## Context

babelfont 3.x renamed `Instance.styleName` to `Instance.name` (an `I18NDictionary` with the same `.get_default()` API). This breaks all fontprimer builds with current toolchain versions, affecting ~110 Google Fonts families (Playwrite, EduAuVic, BriemHand, etc.).

## Test plan

- [ ] Build a fontprimer-based family (e.g., BriemHand) with babelfont 3.1.3
- [ ] Verify the output filename uses the correct style name

🤖 Generated with [Claude Code](https://claude.com/claude-code)